### PR TITLE
Parse status code in the response

### DIFF
--- a/transport/tcp.lisp
+++ b/transport/tcp.lisp
@@ -181,7 +181,9 @@
                     (go read-header-value)
                else if (= byte 0)
                       do (go eof)
-               else
+  	       else if (= byte (char-code #\Return))
+	              do (go read-lf)
+	       else
                  do (fast-write-byte byte buffer)))
 
      read-header-value


### PR DESCRIPTION
In 'read-headers' the end of the status code line is not detected.
It ends up merged with the next header.
When the next header is 'content-length' the call timesout.