### PR TITLE
Added a jsonrpc:*debug-on-error* variable.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,6 +28,8 @@ JSON-RPC 2.0 server/client for Common Lisp.
 ;=> 30
 ```
 
+To invoke an interactive debugger on any errors in your handlers, set `jsonrpc:*debug-on-error*` to `t`.
+
 ## Experimental features (only for Server)
 
 - broadcast

--- a/errors.lisp
+++ b/errors.lisp
@@ -12,8 +12,12 @@
            #:jsonrpc-server-error
            #:jsonrpc-callback-error
            #:jsonrpc-error-code
-           #:jsonrpc-error-message))
+           #:jsonrpc-error-message
+           #:*debug-on-error*))
 (in-package #:jsonrpc/errors)
+
+(defvar *debug-on-error* nil
+  "Open an interactive debugger on any error.")
 
 (define-condition jsonrpc-error (error)
   ((code :initarg :code

--- a/main.lisp
+++ b/main.lisp
@@ -57,6 +57,7 @@
    #:jsonrpc-server-error
    #:jsonrpc-error-code
    #:jsonrpc-error-message
+   #:*debug-on-error*
 
    ;; from this package
    #:make-server

--- a/mapper.lisp
+++ b/mapper.lisp
@@ -60,7 +60,11 @@
         (handler-bind ((error
                          (lambda (e)
                            (unless (typep e 'jsonrpc-error)
-                             (dissect:present e)))))
+                             (cond
+                               (*debug-on-error*
+                                (invoke-debugger e))
+                               (t
+                                (dissect:present e)))))))
           (call-next-method))
       (jsonrpc-error (e)
         (when (request-id request)

--- a/tests/request-response.lisp
+++ b/tests/request-response.lisp
@@ -3,7 +3,9 @@
   (:use #:cl
         #:rove
         #:jsonrpc/request-response
-        #:jsonrpc/errors))
+        #:jsonrpc/errors)
+  (:shadowing-import-from #:rove
+                          #:*debug-on-error*))
 (in-package #:jsonrpc/tests/request-response)
 
 (deftest parse-message-test

--- a/tests/transport/stdio.lisp
+++ b/tests/transport/stdio.lisp
@@ -3,6 +3,8 @@
   (:use #:cl
         #:rove
         #:jsonrpc)
+  (:shadowing-import-from #:rove
+                          #:*debug-on-error*)
   (:import-from #:jsonrpc/transport/stdio)
   (:import-from #:bordeaux-threads))
 (in-package #:jsonrpc/tests/transport/stdio)

--- a/tests/transport/tcp.lisp
+++ b/tests/transport/tcp.lisp
@@ -3,6 +3,8 @@
   (:use #:cl
         #:rove
         #:jsonrpc)
+  (:shadowing-import-from #:rove
+                          #:*debug-on-error*)
   (:import-from #:jsonrpc/transport/tcp)
   (:import-from #:bordeaux-threads))
 (in-package #:jsonrpc/tests/transport/tcp)

--- a/tests/transport/websocket.lisp
+++ b/tests/transport/websocket.lisp
@@ -3,6 +3,8 @@
   (:use #:cl
         #:rove
         #:jsonrpc)
+  (:shadowing-import-from #:rove
+                          #:*debug-on-error*)
   (:import-from #:jsonrpc/transport/websocket)
   (:import-from #:bordeaux-threads))
 (in-package #:jsonrpc/tests/transport/websocket)


### PR DESCRIPTION
It can be set to `t` to raise an interactive debugger on errors in function handlers.