### PR TITLE
Fixed error with TCP transport message encoding.

### DIFF
--- a/transport/tcp.lisp
+++ b/transport/tcp.lisp
@@ -129,18 +129,19 @@
       connection)))
 
 (defmethod send-message-using-transport ((transport tcp-transport) connection message)
-  (let ((json (with-output-to-string (s)
-                (yason:encode message s)))
-        (stream (connection-socket connection)))
+  (let* ((json (with-output-to-string (s)
+                 (yason:encode message s)))
+         (body (string-to-utf-8-bytes json))
+         (stream (connection-socket connection)))
     (write-sequence
      (string-to-utf-8-bytes
       (format nil
-              "Content-Length: ~A~C~C~:*~:*~C~C~A"
-              (length json)
+              "Content-Length: ~A~C~C~:*~:*~C~C"
+              (length body)
               #\Return
-              #\Newline
-              json))
+              #\Newline))
      stream)
+    (write-sequence body stream)
     (force-output stream)))
 
 (defmethod receive-message-using-transport ((transport tcp-transport) connection)


### PR DESCRIPTION
Previously, if you used international strings as message's part
(like Cyrillic letters, for example), jsonrpc was unable to
receive such message, because the number of letters was not
equal to the number of utf-8 octets.

Now we are encoding message before the Content-Length is calculated.