### PR TITLE
Fixed file descriptors leak.

### DIFF
--- a/transport/tcp.lisp
+++ b/transport/tcp.lisp
@@ -86,6 +86,7 @@
                        (unwind-protect
                             (run-reading-loop transport connection)
                          (finish-output (connection-socket connection))
+                         (usocket:socket-close socket)
                          (bt:destroy-thread thread)
                          (emit :close connection))))
                    :name "jsonrpc/transport/tcp reading")


### PR DESCRIPTION
Previously, the server didn't close connection sockets and there was a possibility of the DDoS attack by making a lot of short connections to the server.