### PR TITLE
Some changes to talk with chrome devtools api.

### DIFF
--- a/class.lisp
+++ b/class.lisp
@@ -39,6 +39,7 @@
   (:import-from #:alexandria
                 #:remove-from-plist)
   (:export #:*default-timeout*
+           #:*default-id-type*
            #:client
            #:server
            #:jsonrpc-transport
@@ -63,6 +64,7 @@
 (in-package #:jsonrpc/class)
 
 (defvar *default-timeout* 60)
+(defvar *default-id-type* :string)
 
 (defclass jsonrpc (event-emitter exposable)
   ((transport :type (or null transport)
@@ -154,7 +156,7 @@
 
 (defun call-async-to (from to method &optional params callback error-callback)
   (check-type params jsonrpc-params)
-  (let ((id (make-id)))
+  (let ((id (make-id :id-type *default-id-type*)))
     (set-callback-for-id to
                          id
                          (lambda (response)

--- a/main.lisp
+++ b/main.lisp
@@ -19,6 +19,7 @@
    #:response-result
    #:response-id
    #:parse-message
+   #:*response-need-jsonrpc-p*
 
    ;; from transports
    #:transport
@@ -27,6 +28,7 @@
 
    ;; from class
    #:*default-timeout*
+   #:*default-id-type*
    #:server
    #:client
    #:server-listen

--- a/request-response.lisp
+++ b/request-response.lisp
@@ -24,8 +24,13 @@
            #:response-error-code
            #:response-result
            #:response-id
-           #:parse-message))
+           #:parse-message
+           #:*response-need-jsonrpc-p*))
 (in-package #:jsonrpc/request-response)
+
+;; chrome devtools api is not jsonrpc2.0 compliant.
+;; It respond without "jsonrpc" field.
+(defvar *response-need-jsonrpc-p* t)
 
 (defstruct request
   method
@@ -67,7 +72,9 @@
               (hash-table-keys request))))
 
 (defun valid-response-p (response)
-  (and (equal (gethash "jsonrpc" response) "2.0")
+  (and (if *response-need-jsonrpc-p*
+           (equal (gethash "jsonrpc" response) "2.0")
+         t)
        (typep (gethash "error" response)
               '(or null hash-table))
        (typep (gethash "id" response)

--- a/transport/websocket.lisp
+++ b/transport/websocket.lisp
@@ -32,6 +32,9 @@
    (port :accessor websocket-transport-port
          :initarg :port
          :initform (random-port))
+   (path :accessor websocket-transport-path
+         :initarg :path
+         :initform "/")
    (securep :accessor websocket-transport-secure-p
             :initarg :securep
             :initform nil)
@@ -47,7 +50,8 @@
       (setf (websocket-transport-secure-p transport)
             (equalp (quri:uri-scheme uri) "wss"))
       (setf (websocket-transport-host transport) (quri:uri-host uri))
-      (setf (websocket-transport-port transport) (quri:uri-port uri))))
+      (setf (websocket-transport-port transport) (quri:uri-port uri))
+      (setf (websocket-transport-path transport) (or (quri:uri-path uri) "/"))))
   transport)
 
 (defmethod start-server ((transport websocket-transport))
@@ -99,12 +103,13 @@
          :use-thread nil)))
 
 (defmethod start-client ((transport websocket-transport))
-  (let* ((client (wsd:make-client (format nil "~A://~A:~A/"
+  (let* ((client (wsd:make-client (format nil "~A://~A:~A~A"
                                           (if (websocket-transport-secure-p transport)
                                               "wss"
                                               "ws")
                                           (websocket-transport-host transport)
-                                          (websocket-transport-port transport))))
+                                          (websocket-transport-port transport)
+                                          (websocket-transport-path transport))))
          (connection (make-instance 'connection
                                     :socket client
                                     :request-callback

--- a/utils.lisp
+++ b/utils.lisp
@@ -24,8 +24,13 @@
         if (port-available-p port)
           return port))
 
-(defun make-id (&optional (length 12))
+(defvar *id* 0)
+(defun make-id (&key (id-type :string) (length 12))
   (declare (type fixnum length))
+  (check-type id-type (member :string :number))
+
+  (when (eql :number id-type) (return-from make-id (incf *id*)))
+
   (let ((result (make-string length)))
     (declare (type simple-string result))
     (dotimes (i length result)


### PR DESCRIPTION
Some changes to talk with [chrome devtools api](https://github.com/aslushnikov/getting-started-with-cdp/blob/master/README.md). 

- Websocket client can specify endpoint url with path. Currently path of url is ignored.
  Chrome devtools api needs path.
- Number is available as request id. With `*default-id-type*` being :number.
- Avoid validation for response's `jsonrpc` field. With `*response-need-jsonrpc-p*` being nil.
  Chrome devtools api respond without `jsonrpc` field. 

Example to talk with chrome devtools api.

```lisp
(ql:quickload :jsonrpc)
(ql:quickload :dexador)
(ql:quickload :osicat)

(setf jsonrpc:*response-need-jsonrpc-p* nil)
(setf jsonrpc:*default-id-type* :number)

(uiop:launch-program (list "chrome"
                           "--remote-debugging-port=9222"
                           "--no-first-run"
                           "--no-default-browser-check"
                           (format nil "--user-data-dir=~a" (osicat-posix:mkdtemp "/tmp/chrome-XXXXXX")))
                     :input :interactive)
                     
(defparameter *c* (jsonrpc:make-client))

(jsonrpc:client-connect
 *c*
 :url (gethash "webSocketDebuggerUrl" (yason:parse (dex:get "http://localhost:9222/json/new")))
 ;; like ws://localhost:9222/devtools/page/B1318FC17806F913923403677CF5521C
 :mode :websocket)
 
(jsonrpc:call
 *c*
 "Page.navigate"
 (let ((message (make-hash-table :test 'equal)))
   (setf (gethash "url" message) "https://apple.com/watch")
   message))
```


