### PR TITLE
Avoid errors when shutting down

### DIFF
--- a/class.lisp
+++ b/class.lisp
@@ -28,10 +28,10 @@
                 #:jsonrpc-callback-error)
   (:import-from #:jsonrpc/utils
                 #:find-mode-class
-                #:make-id)
+                #:make-id
+                #:destroy-thread*)
   (:import-from #:bordeaux-threads
-                #:*default-special-bindings*
-                #:destroy-thread)
+                #:*default-special-bindings*)
   (:import-from #:event-emitter
                 #:on
                 #:emit
@@ -135,7 +135,7 @@
 (defun client-disconnect (client)
   (ensure-connected client)
   (let ((transport (jsonrpc-transport client)))
-    (mapc #'bt:destroy-thread (transport-threads transport))
+    (mapc #'destroy-thread* (transport-threads transport))
     (setf (transport-threads transport) '())
     (setf (transport-connection transport) nil))
   (emit :close client)

--- a/tests/transport/tcp.lisp
+++ b/tests/transport/tcp.lisp
@@ -6,6 +6,7 @@
   (:shadowing-import-from #:rove
                           #:*debug-on-error*)
   (:import-from #:jsonrpc/transport/tcp)
+  (:import-from #:jsonrpc/utils #:destroy-thread*)
   (:import-from #:bordeaux-threads))
 (in-package #:jsonrpc/tests/transport/tcp)
 
@@ -23,5 +24,5 @@
            (sleep 0.5)
            (jsonrpc:client-connect client :url "http://127.0.0.1:50879" :mode :tcp)
            (ok (= (jsonrpc:call client "sum" '(10 20)) 30)))
-      (bt:destroy-thread server-thread)
+      (destroy-thread* server-thread)
       (jsonrpc:client-disconnect client))))

--- a/tests/transport/websocket.lisp
+++ b/tests/transport/websocket.lisp
@@ -5,6 +5,7 @@
         #:jsonrpc)
   (:shadowing-import-from #:rove
                           #:*debug-on-error*)
+  (:import-from #:jsonrpc/utils #:destroy-thread*)
   (:import-from #:jsonrpc/transport/websocket)
   (:import-from #:bordeaux-threads))
 (in-package #:jsonrpc/tests/transport/websocket)
@@ -31,5 +32,5 @@
                  do (sleep 0.1))
            (jsonrpc:client-connect client :url "ws://127.0.0.1:50879" :mode :websocket)
            (ok (= (jsonrpc:call client "sum" '(10 20)) 30)))
-      (bt:destroy-thread server-thread)
+      (destroy-thread* server-thread)
       (jsonrpc:client-disconnect client))))

--- a/transport/interface.lisp
+++ b/transport/interface.lisp
@@ -57,6 +57,8 @@
 
 (defgeneric run-reading-loop (transport connection)
   (:method ((transport transport) connection)
-    (loop for message = (receive-message-using-transport transport connection)
-          while message
-          do (add-message-to-queue connection message))))
+    (handler-case
+        (loop for message = (receive-message-using-transport transport connection)
+              while message
+              do (add-message-to-queue connection message))
+      (end-of-file ()))))

--- a/transport/interface.lisp
+++ b/transport/interface.lisp
@@ -43,17 +43,20 @@
   (:method ((transport transport) connection)
     (let ((request-queue (connection-request-queue connection))
           (outbox (connection-outbox connection)))
-      (loop
-        (when (and (chanl:recv-blocks-p request-queue)
-                   (chanl:recv-blocks-p outbox))
-          (wait-for-ready connection))
-        (chanl:select
-          ((chanl:recv request-queue request)
-           (let ((response (process-request connection request)))
-             (when response
-               (add-message-to-outbox connection response))))
-          ((chanl:recv outbox message)
-           (send-message-using-transport transport connection message)))))))
+      (handler-case
+          (loop
+            (when (and (chanl:recv-blocks-p request-queue)
+                       (chanl:recv-blocks-p outbox))
+              (wait-for-ready connection))
+            (chanl:select
+              ((chanl:recv request-queue request)
+               (let ((response (process-request connection request)))
+                 (when response
+                   (add-message-to-outbox connection response))))
+              ((chanl:recv outbox message)
+               (send-message-using-transport transport connection message)))
+          ;; Broken pipe.
+          (stream-error ()))))))
 
 (defgeneric run-reading-loop (transport connection)
   (:method ((transport transport) connection)

--- a/transport/interface.lisp
+++ b/transport/interface.lisp
@@ -54,9 +54,9 @@
                  (when response
                    (add-message-to-outbox connection response))))
               ((chanl:recv outbox message)
-               (send-message-using-transport transport connection message)))
-          ;; Broken pipe.
-          (stream-error ()))))))
+               (send-message-using-transport transport connection message))))
+        ;; Broken pipe or "something bad happened" from chanl
+        ((or stream-error #+ccl simple-error) ())))))
 
 (defgeneric run-reading-loop (transport connection)
   (:method ((transport transport) connection)

--- a/transport/stdio.lisp
+++ b/transport/stdio.lisp
@@ -7,8 +7,9 @@
                 #:connection-socket)
   (:import-from #:yason)
   (:import-from #:bordeaux-threads
-                #:make-thread
-                #:destroy-thread)
+                #:make-thread)
+  (:import-from #:jsonrpc/utils
+                #:destroy-thread*)
   (:import-from #:jsonrpc/request-response
                 #:parse-message)
   (:export #:stdio-transport))
@@ -37,7 +38,7 @@
                (run-processing-loop transport connection))
              :name "jsonrpc/transport/stdio processing")))
       (unwind-protect (run-reading-loop transport connection)
-        (bt:destroy-thread thread)))))
+        (destroy-thread* thread)))))
 
 (defmethod start-client ((transport stdio-transport))
   (let* ((stream (make-two-way-stream (stdio-transport-input transport)

--- a/transport/tcp.lisp
+++ b/transport/tcp.lisp
@@ -13,8 +13,7 @@
   (:import-from #:quri)
   (:import-from #:yason)
   (:import-from #:bordeaux-threads
-                #:make-thread
-                #:destroy-thread)
+                #:make-thread)
   (:import-from #:fast-io
                 #:make-output-buffer
                 #:finish-output-buffer
@@ -87,11 +86,11 @@
                             (run-reading-loop transport connection)
                          (finish-output (connection-socket connection))
                          (usocket:socket-close socket)
-                         (bt:destroy-thread thread)
+                         (destroy-thread* thread)
                          (emit :close connection))))
                    :name "jsonrpc/transport/tcp reading")
                   client-threads))))
-        (mapc #'bt:destroy-thread client-threads)))))
+        (mapc #'destroy-thread* client-threads)))))
 
 (defmethod start-client ((transport tcp-transport))
   (let ((stream (usocket:socket-stream

--- a/transport/websocket.lisp
+++ b/transport/websocket.lisp
@@ -12,8 +12,7 @@
   (:import-from #:jsonrpc/errors
                 #:jsonrpc-error)
   (:import-from #:bordeaux-threads
-                #:make-thread
-                #:destroy-thread)
+                #:make-thread)
   (:import-from #:event-emitter
                 #:on
                 #:emit)

--- a/utils.lisp
+++ b/utils.lisp
@@ -7,10 +7,12 @@
                 #:address-in-use-error)
   (:import-from #:bordeaux-threads
                 #:make-lock
-                #:with-lock-held)
+                #:with-lock-held
+                #:destroy-thread)
   (:export #:random-port
            #:make-id
-           #:find-mode-class))
+           #:find-mode-class
+           #:destroy-thread*))
 (in-package #:jsonrpc/utils)
 
 (defun port-available-p (port)
@@ -53,3 +55,8 @@
                     (find-package package-name))))))
       (and package
            (find-class (intern (format nil "~A-~A" mode :transport) package))))))
+
+(defun destroy-thread* (thread)
+  (handler-case
+      (bt:destroy-thread thread)
+    ((or #+sbcl sb-thread:interrupt-thread-error) ())))


### PR DESCRIPTION
This tries to prevent signaling errors when the server is shut down or a client disconnects. Such errors can come from (1) trying to interrupt a thread that has already exited, (2) a background thread trying to read from a closed stream, or (3) a background thread trying to write to a closed stream.