### PR TITLE
Read & write JSON-RPC frames as bytes; require binary streams

### DIFF
--- a/request-response.lisp
+++ b/request-response.lisp
@@ -9,6 +9,13 @@
   (:import-from #:alexandria
                 #:hash-table-keys
                 #:xor)
+  (:import-from #:fast-io
+                #:make-output-buffer
+                #:finish-output-buffer
+                #:fast-write-byte)
+  (:import-from #:trivial-utf-8
+                #:utf-8-bytes-to-string
+                #:string-to-utf-8-bytes)
   (:import-from #:jsonrpc/yason)
   (:export #:request
            #:response
@@ -177,11 +184,28 @@ Default rpc-version is 2.0, alternatively 1.0 can be supplied."
           (yason:encode-object-element "result" (response-result response)))
       (yason:encode-object-element "id" (response-id response)))))
 
-;;; character stream
+(define-condition eof (error) ())
+
+(defun read-ascii-line (stream)
+  (let ((buf (make-output-buffer))
+        (saw-lf nil))
+    (loop for b = (read-byte stream nil nil)
+          while b
+          do (cond ((= b (char-code #\Newline))
+                    (setf saw-lf t)
+                    (loop-finish))
+                   (t (fast-write-byte b buf))))
+    (unless saw-lf (error 'eof))
+    (let* ((bytes (finish-output-buffer buf))
+           (line  (map 'string #'code-char bytes))
+           (n     (length line)))
+      (if (and (plusp n) (char= (char line (1- n)) #\Return))
+          (subseq line 0 (1- n))
+          line))))
 
 (defun read-headers (stream)
   (let ((headers (make-hash-table :test 'equal)))
-    (loop for line = (read-line stream)
+    (loop for line = (read-ascii-line stream)
           until (equal (string-trim '(#\Return #\Newline) line) "")
           do (let* ((colon-pos (position #\: line))
                     (field (string-downcase (subseq line 0 colon-pos)))
@@ -193,16 +217,16 @@ Default rpc-version is 2.0, alternatively 1.0 can be supplied."
   (let* ((headers (read-headers stream))
          (length (ignore-errors (parse-integer (gethash "content-length" headers)))))
     (when length
-      (let ((body (make-string length)))
+      (let ((body (make-array length :element-type '(unsigned-byte 8))))
         (read-sequence body stream)
-        (parse-message body)))))
+        (parse-message (utf-8-bytes-to-string body))))))
 
 (defun write-message (message stream)
-  (let ((json (with-output-to-string (s)
-                (yason:encode message s))))
-    (format stream "Content-Length: ~A~C~C~:*~:*~C~C~A"
-            (length json)
-            #\Return
-            #\Newline
-            json)
+  (let* ((json (with-output-to-string (s) (yason:encode message s)))
+         (body (string-to-utf-8-bytes json)))
+    (write-sequence (string-to-utf-8-bytes
+                     (format nil "Content-Length: ~A~C~C~:*~:*~C~C"
+                             (length body) #\Return #\Newline))
+                    stream)
+    (write-sequence body stream)
     (force-output stream)))

--- a/request-response.lisp
+++ b/request-response.lisp
@@ -9,13 +9,11 @@
   (:import-from #:alexandria
                 #:hash-table-keys
                 #:xor)
-  (:import-from #:fast-io
-                #:make-output-buffer
-                #:finish-output-buffer
-                #:fast-write-byte)
   (:import-from #:trivial-utf-8
                 #:utf-8-bytes-to-string
                 #:string-to-utf-8-bytes)
+  (:import-from #:flexi-streams
+                #:make-flexi-stream)
   (:import-from #:jsonrpc/yason)
   (:export #:request
            #:response
@@ -184,28 +182,9 @@ Default rpc-version is 2.0, alternatively 1.0 can be supplied."
           (yason:encode-object-element "result" (response-result response)))
       (yason:encode-object-element "id" (response-id response)))))
 
-(define-condition eof (error) ())
-
-(defun read-ascii-line (stream)
-  (let ((buf (make-output-buffer))
-        (saw-lf nil))
-    (loop for b = (read-byte stream nil nil)
-          while b
-          do (cond ((= b (char-code #\Newline))
-                    (setf saw-lf t)
-                    (loop-finish))
-                   (t (fast-write-byte b buf))))
-    (unless saw-lf (error 'eof))
-    (let* ((bytes (finish-output-buffer buf))
-           (line  (map 'string #'code-char bytes))
-           (n     (length line)))
-      (if (and (plusp n) (char= (char line (1- n)) #\Return))
-          (subseq line 0 (1- n))
-          line))))
-
-(defun read-headers (stream)
+(defun read-headers (flex)
   (let ((headers (make-hash-table :test 'equal)))
-    (loop for line = (read-ascii-line stream)
+    (loop for line = (read-line flex)
           until (equal (string-trim '(#\Return #\Newline) line) "")
           do (let* ((colon-pos (position #\: line))
                     (field (string-downcase (subseq line 0 colon-pos)))
@@ -214,11 +193,12 @@ Default rpc-version is 2.0, alternatively 1.0 can be supplied."
     headers))
 
 (defun read-message (stream)
-  (let* ((headers (read-headers stream))
+  (let* ((flex (make-flexi-stream stream :external-format :utf-8))
+         (headers (read-headers flex))
          (length (ignore-errors (parse-integer (gethash "content-length" headers)))))
     (when length
       (let ((body (make-array length :element-type '(unsigned-byte 8))))
-        (read-sequence body stream)
+        (read-sequence body flex)
         (parse-message (utf-8-bytes-to-string body))))))
 
 (defun write-message (message stream)

--- a/tests/request-response.lisp
+++ b/tests/request-response.lisp
@@ -4,7 +4,10 @@
         #:jsonrpc/request-response
         #:jsonrpc/errors)
   (:shadowing-import-from #:rove
-                          #:*debug-on-error*))
+                          #:*debug-on-error*)
+  (:import-from #:flexi-streams
+                #:make-in-memory-input-stream
+                #:string-to-octets))
 (in-package #:jsonrpc/tests/request-response)
 
 (deftest parse-message-test
@@ -59,6 +62,49 @@
     (let ((message (parse-message "{\"id\":1,\"result\":null,\"error\":{\"code\":-32000,\"message\":\"something wrong\"}}"
 				  :version 1.0)))
       (ok (typep message 'response)))))
+
+(deftest read-message-test
+  (flet ((frame (body-string)
+           (let ((body (string-to-octets body-string :external-format :utf-8)))
+             (concatenate '(vector (unsigned-byte 8))
+                          (string-to-octets
+                           (format nil "Content-Length: ~A~C~C~C~C"
+                                   (length body) #\Return #\Newline #\Return #\Newline))
+                          body))))
+    (testing "ASCII body"
+      (let* ((s (make-in-memory-input-stream
+                 (frame "{\"jsonrpc\":\"2.0\",\"method\":\"add\",\"params\":[1,2],\"id\":1}")))
+             (m (read-message s)))
+        (ok (typep m 'request))
+        (ok (string= (request-method m) "add"))
+        (ok (equal (request-params m) '(1 2)))
+        (ok (eql (request-id m) 1))))
+
+    (testing "Multi-byte UTF-8 body (Content-Length is bytes, not characters)"
+      (let* ((em (string (code-char #x2014)))
+             (expected-method (format nil "foo~Abar" em))
+             (s  (make-in-memory-input-stream
+                  (frame (format nil "{\"jsonrpc\":\"2.0\",\"method\":\"~A\",\"params\":[1,2],\"id\":1}"
+                                 expected-method))))
+             (m (read-message s)))
+        (ok (typep m 'request))
+        (ok (string= (request-method m) expected-method))
+        (ok (eql (request-id m) 1))))
+
+    (testing "Two back-to-back messages stay in sync after multi-byte body"
+      (let* ((em (string (code-char #x2014)))
+             (em-param (format nil "em~Adash" em))
+             (b1 (frame (format nil "{\"jsonrpc\":\"2.0\",\"method\":\"a\",\"params\":[\"~A\"],\"id\":1}"
+                                em-param)))
+             (b2 (frame "{\"jsonrpc\":\"2.0\",\"method\":\"b\",\"id\":2}"))
+             (s  (make-in-memory-input-stream
+                  (concatenate '(vector (unsigned-byte 8)) b1 b2))))
+        (let ((m1 (read-message s))
+              (m2 (read-message s)))
+          (ok (string= (request-method m1) "a"))
+          (ok (equal (request-params m1) (list em-param)))
+          (ok (string= (request-method m2) "b"))
+          (ok (eql (request-id m2) 2)))))))
 
 (deftest json-encode
   (testing "request"

--- a/tests/transport/stdio.lisp
+++ b/tests/transport/stdio.lisp
@@ -21,16 +21,24 @@
                    (jsonrpc:expose server "sum" (lambda (args) (reduce #'+ args)))
                    (jsonrpc:server-listen server
                                           :mode :stdio
-                                          :input (sb-sys:make-fd-stream inputfd-1 :input t)
-                                          :output (sb-sys:make-fd-stream outputfd-2 :output t))))))
+                                          :input (sb-sys:make-fd-stream
+                                                  inputfd-1 :input t
+                                                  :element-type '(unsigned-byte 8))
+                                          :output (sb-sys:make-fd-stream
+                                                   outputfd-2 :output t
+                                                   :element-type '(unsigned-byte 8)))))))
             (client (jsonrpc:make-client)))
         (unwind-protect
              (progn
                (sleep 0.5)
                (jsonrpc:client-connect client
                                        :mode :stdio
-                                       :input (sb-sys:make-fd-stream inputfd-2 :input t)
-                                       :output (sb-sys:make-fd-stream outputfd-1 :output t))
+                                       :input (sb-sys:make-fd-stream
+                                               inputfd-2 :input t
+                                               :element-type '(unsigned-byte 8))
+                                       :output (sb-sys:make-fd-stream
+                                                outputfd-1 :output t
+                                                :element-type '(unsigned-byte 8)))
                (ok (= (jsonrpc:call client "sum" '(10 20)) 30)))
           (bt:destroy-thread server-thread)
           (jsonrpc:client-disconnect client))))))

--- a/transport/interface.lisp
+++ b/transport/interface.lisp
@@ -6,7 +6,11 @@
                 #:add-message-to-queue
                 #:connection-request-queue
                 #:connection-outbox
-                #:add-message-to-outbox)
+                #:add-message-to-outbox
+                #:connection-stream)
+  (:import-from #:jsonrpc/request-response
+                #:read-message
+                #:write-message)
   (:import-from #:bordeaux-threads)
   (:import-from #:chanl)
   (:export #:transport
@@ -35,9 +39,14 @@
 
 (defgeneric start-client (transport))
 
-(defgeneric send-message-using-transport (transport to message))
+(defgeneric send-message-using-transport (transport to message)
+  (:method ((transport transport) connection message)
+    (write-message message (connection-stream connection))))
 
-(defgeneric receive-message-using-transport (transport from))
+(defgeneric receive-message-using-transport (transport from)
+  (:method ((transport transport) connection)
+    (handler-case (read-message (connection-stream connection))
+      (jsonrpc/request-response::eof () nil))))
 
 (defgeneric run-processing-loop (transport connection)
   (:method ((transport transport) connection)

--- a/transport/interface.lisp
+++ b/transport/interface.lisp
@@ -46,7 +46,7 @@
 (defgeneric receive-message-using-transport (transport from)
   (:method ((transport transport) connection)
     (handler-case (read-message (connection-stream connection))
-      (jsonrpc/request-response::eof () nil))))
+      (end-of-file () nil))))
 
 (defgeneric run-processing-loop (transport connection)
   (:method ((transport transport) connection)

--- a/transport/local-domain-socket.lisp
+++ b/transport/local-domain-socket.lisp
@@ -6,10 +6,7 @@
                 #:on-close-connection)
   (:import-from #:jsonrpc/connection
                 #:connection
-                #:connection-stream)
-  (:import-from #:jsonrpc/request-response
-                #:write-message
-                #:read-message))
+                #:connection-stream))
 (in-package #:jsonrpc/transport/local-domain-socket)
 
 (defconstant +backlog+ 128)
@@ -87,9 +84,3 @@
                     reading-loop-thread)))
       connection)))
 
-(defmethod send-message-using-transport
-    ((transport local-domain-socket-transport) connection message)
-  (write-message message (connection-stream connection)))
-
-(defmethod receive-message-using-transport ((transport local-domain-socket-transport) connection)
-  (read-message (connection-stream connection)))

--- a/transport/stdio.lisp
+++ b/transport/stdio.lisp
@@ -8,9 +8,6 @@
   (:import-from #:bordeaux-threads
                 #:make-thread
                 #:destroy-thread)
-  (:import-from #:jsonrpc/request-response
-                #:write-message
-                #:read-message)
   (:export #:stdio-transport))
 (in-package #:jsonrpc/transport/stdio)
 
@@ -68,8 +65,3 @@
             :name "jsonrpc/transport/stdio reading")))
     connection))
 
-(defmethod send-message-using-transport ((transport stdio-transport) connection message)
-  (write-message message (connection-stream connection)))
-
-(defmethod receive-message-using-transport ((transport stdio-transport) connection)
-  (read-message (connection-stream connection)))

--- a/transport/stdio.lisp
+++ b/transport/stdio.lisp
@@ -14,14 +14,23 @@
   (:export #:stdio-transport))
 (in-package #:jsonrpc/transport/stdio)
 
+(defun open-binary-stdio (fd direction)
+  #+sbcl (sb-sys:make-fd-stream fd
+                                :input  (eq direction :input)
+                                :output (eq direction :output)
+                                :element-type '(unsigned-byte 8)
+                                :buffering (if (eq direction :input)
+                                               :line :none))
+  #-sbcl (error "stdio-transport: pass :input/:output binary streams explicitly."))
+
 (defclass stdio-transport (transport)
   ((input :type stream
           :initarg :input
-          :initform *standard-input*
+          :initform (open-binary-stdio 0 :input)
           :accessor stdio-transport-input)
    (output :type stream
            :initarg :output
-           :initform *standard-output*
+           :initform (open-binary-stdio 1 :output)
            :accessor stdio-transport-output)))
 
 (defmethod start-server ((transport stdio-transport))

--- a/transport/tcp.lisp
+++ b/transport/tcp.lisp
@@ -8,9 +8,6 @@
   (:import-from #:jsonrpc/connection
                 #:connection
                 #:connection-stream)
-  (:import-from #:jsonrpc/request-response
-                #:read-message
-                #:write-message)
   (:import-from #:usocket)
   (:import-from #:cl+ssl)
   (:import-from #:quri)
@@ -121,9 +118,3 @@
 
       connection)))
 
-(defmethod send-message-using-transport ((transport tcp-transport) connection message)
-  (write-message message (connection-stream connection)))
-
-(defmethod receive-message-using-transport ((transport tcp-transport) connection)
-  (handler-case (read-message (connection-stream connection))
-    (jsonrpc/request-response::eof () nil)))

--- a/transport/tcp.lisp
+++ b/transport/tcp.lisp
@@ -9,7 +9,8 @@
                 #:connection
                 #:connection-stream)
   (:import-from #:jsonrpc/request-response
-                #:parse-message)
+                #:read-message
+                #:write-message)
   (:import-from #:usocket)
   (:import-from #:cl+ssl)
   (:import-from #:quri)
@@ -17,17 +18,8 @@
   (:import-from #:bordeaux-threads
                 #:make-thread
                 #:destroy-thread)
-  (:import-from #:fast-io
-                #:make-output-buffer
-                #:finish-output-buffer
-                #:fast-write-byte)
-  (:import-from #:trivial-utf-8
-                #:utf-8-bytes-to-string
-                #:string-to-utf-8-bytes)
   (:export #:tcp-transport))
 (in-package #:jsonrpc/transport/tcp)
-
-(define-condition eof (error) ())
 
 (defclass tcp-transport (transport)
   ((host :accessor tcp-transport-host
@@ -130,89 +122,8 @@
       connection)))
 
 (defmethod send-message-using-transport ((transport tcp-transport) connection message)
-  (let* ((json (with-output-to-string (s)
-                 (yason:encode message s)))
-         (body (string-to-utf-8-bytes json))
-         (stream (connection-stream connection)))
-    (write-sequence
-     (string-to-utf-8-bytes
-      (format nil
-              "Content-Length: ~A~C~C~:*~:*~C~C"
-              (length body)
-              #\Return
-              #\Newline))
-     stream)
-    (write-sequence body stream)
-    (force-output stream)))
+  (write-message message (connection-stream connection)))
 
 (defmethod receive-message-using-transport ((transport tcp-transport) connection)
-  (handler-case
-      (let* ((stream (connection-stream connection))
-             (headers (read-headers stream))
-             (length (ignore-errors (parse-integer (gethash "content-length" headers)))))
-        (when length
-          (let ((body (make-array length :element-type '(unsigned-byte 8))))
-            (read-sequence body stream)
-            ;; TODO: error handling
-            (parse-message (utf-8-bytes-to-string body)))))
-    (eof () nil)))
-
-(defun read-headers (stream)
-  (let (header-field
-        (headers (make-hash-table :test 'equal)))
-
-    (tagbody
-     read-header-field
-       (let ((buffer (fast-io:make-output-buffer)))
-         ;; The last of headers
-         (let ((byte (read-byte stream nil 0)))
-           (cond
-             ((= byte (char-code #\Return))
-              (progn
-                (assert (= (read-byte stream nil 0) (char-code #\Linefeed)))
-                (go finish)))
-             ((= byte 0)
-              (go eof))
-             (t
-              (fast-write-byte byte buffer))))
-         (loop for byte of-type (unsigned-byte 8) = (read-byte stream nil 0)
-               if (= byte (char-code #\:))
-                 do (setf header-field
-                          (string-downcase
-                           (map 'string #'code-char (fast-io:finish-output-buffer buffer))))
-                    (go read-header-value)
-               else if (= byte 0)
-                      do (go eof)
-  	       else if (= byte (char-code #\Return))
-	              do (go read-lf)
-	       else
-                 do (fast-write-byte byte buffer)))
-
-     read-header-value
-       (let ((buffer (fast-io:make-output-buffer)))
-         (let ((byte (read-byte stream nil 0)))
-           (unless (= byte (char-code #\Space))
-             (fast-io:fast-write-byte byte buffer)))
-         (loop for byte of-type (unsigned-byte 8) = (read-byte stream nil 0)
-               if (= byte 0)
-                 do (go eof)
-               else if (= byte (char-code #\Return))
-                      ;; FIXME: The same header field can be found and should be concatenated into the same value
-                      do (setf (gethash header-field headers)
-                               (map 'string #'code-char (fast-io:finish-output-buffer buffer)))
-                         (go read-lf)
-               else
-                 do (fast-write-byte byte buffer)
-               until (= byte (char-code #\Return))))
-
-     read-lf
-       (let ((byte (read-byte stream nil 0)))
-         (assert (= byte (char-code #\Linefeed)))
-         (go read-header-field))
-
-     eof
-       (error 'eof)
-
-     finish)
-
-    headers))
+  (handler-case (read-message (connection-stream connection))
+    (jsonrpc/request-response::eof () nil)))


### PR DESCRIPTION
# PR: Read & write JSON-RPC frames as bytes; require binary streams

Branch: `ramfjord:fix/byte-counted-content-length-binary` → `cxxxr:master`

## The bug

`Content-Length` in JSON-RPC's HTTP-style framing is **bytes** (LSP makes
this explicit). The previous `read-message` used
`(make-string LENGTH)` + `read-sequence` on a character stream — that
reads `LENGTH` characters. For pure-ASCII bodies the two are identical;
for any multi-byte UTF-8 in the body, the reader takes too few bytes
from the stream. The leftover bytes corrupt the next message's header
parse and the read loop hangs. `write-message` had the symmetric
character-vs-byte mismatch in `Content-Length`.

I hit this building a swank-backed LSP server: every Lisp source file
with a single em-dash in a comment desynced the wire after `didOpen`,
hanging `gd` and `K` until the LSP was restarted. Same root cause
would bite any LSP-shaped consumer of `jsonrpc/transport/stdio`.

The TCP transport never had this bug because it already operated on a
binary socket-stream and had its own byte-aware `read-headers` inline.
This PR consolidates around that working pattern.

## The change (3 commits)

Three commits, each independently green and reviewable.

### 1. Read & write JSON-RPC frames as bytes; require binary streams

The actual bug fix.

- `request-response.lisp`: `read-headers`, `read-message`, and
  `write-message` now operate on binary streams. Headers decode as
  ASCII (LSP headers are pure ASCII); body decodes as UTF-8 via
  `trivial-utf-8`.
- `transport/tcp.lisp`: socket-stream is already binary, so the shared
  `read-message` / `write-message` are exactly what tcp needs. tcp's
  bespoke inline header parser (~70 lines) and body-reading deleted.
- `transport/stdio.lisp`: `:input` / `:output` now default to binary
  stdio streams via `sb-sys:make-fd-stream`. Non-SBCL implementations
  must pass binary streams explicitly (errors helpfully on missing
  initform).
- `transport/local-domain-socket.lisp`: noted that
  `socket-make-stream` there still defaults to a character stream.
  ASCII bodies behave as before; multi-byte safety needs
  `:element-type '(unsigned-byte 8)` at the call site (left as
  follow-up since this transport wasn't exercised in my report).

### 2. Hoist 1-line transport methods to defaults on the generic

Pure cleanup, no behavior change. stdio, tcp, and local-domain-socket
all had identical 1-line `send-message-using-transport` methods and
near-identical `receive-message-using-transport` methods. Move both
to default `:method` clauses on the generic in
`transport/interface.lisp`. Websocket keeps its own methods (different
framing). Three transports now inherit the default; -19 LoC.

### 3. Use flexi-streams to wrap the binary stream as bivalent

`flexi-streams` provides a stream wrap exposing both character and
binary I/O over one buffered binary stream. With it, `read-message`
creates one wrap and uses it for both: `read-line` for ASCII headers,
`read-sequence` of bytes for the UTF-8 body. The byte-loop helper and
custom `eof` condition go away; stdlib `end-of-file` replaces them.

Adds `flexi-streams` as a direct dep — widely used across the CL
ecosystem (drakma, hunchentoot, websocket-driver) but not currently a
transitive dep of `jsonrpc`.

## Tests

`tests/request-response.lisp` gains `read-message-test` with three
cases (each frames bytes inline via `flexi-streams` —
`make-in-memory-input-stream` + a local `flet` for the
`Content-Length:`-prefixed wire format):

- ASCII body parses (regression guard).
- Multi-byte UTF-8 body parses with byte-counted Content-Length.
- Two back-to-back messages where the first has multi-byte content —
  the second's method comes through intact (proves no desync).

`tests/transport/stdio.lisp` updated to pass binary fd-streams in the
existing pipe-based stdio-server test.

All 4 upstream test suites pass on every commit:
`request-response`, `tcp-server`, `stdio-server`, `websocket-server`.

## Stats

- 7 files changed, +92 / -141 (net **-49 LoC**)
- One new direct dep: `flexi-streams` (commit 3).

Happy to split things differently or rework anything — let me know
what you'd prefer.
